### PR TITLE
Pré configurando ambiente para criação dos sockets

### DIFF
--- a/deploy/production/bootstrap.sh
+++ b/deploy/production/bootstrap.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+mkdir -p /var/run/webapps/chamados
+chown -R www-data: /var/run/webapps

--- a/deploy/production/supervisor.conf
+++ b/deploy/production/supervisor.conf
@@ -1,3 +1,12 @@
+[program:bootstrap]
+command=/usr/share/webapps/chamados/deploy/production/bootstrap.sh
+directory=/usr/share/webapps/chamados
+user=root
+stopsignal=KILL
+redirect_stderr=True
+stdout_logfile=/var/log/supervisor/chamados.stdout.log
+stderr_logfile=/var/log/supervisor/chamados.stderr.log
+
 [program:chamados]
 command=/usr/share/webapps/chamados/deploy/production/run.sh
 directory=/usr/share/webapps/chamados

--- a/deploy/staging/bootstrap.sh
+++ b/deploy/staging/bootstrap.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+mkdir -p /var/run/webapps/chamados
+chown -R www-data: /var/run/webapps

--- a/deploy/staging/supervisor.conf
+++ b/deploy/staging/supervisor.conf
@@ -1,3 +1,12 @@
+[program:bootstrap]
+command=/usr/share/webapps/chamados/deploy/staging/bootstrap.sh
+directory=/usr/share/webapps/chamados
+user=root
+stopsignal=KILL
+redirect_stderr=True
+stdout_logfile=/var/log/supervisor/chamados.stdout.log
+stderr_logfile=/var/log/supervisor/chamados.stderr.log
+
 [program:chamados]
 command=/usr/share/webapps/chamados/deploy/staging/run.sh
 directory=/usr/share/webapps/chamados

--- a/fabfile.py
+++ b/fabfile.py
@@ -213,14 +213,11 @@ def git_update():
 
 @task 
 def cria_links():
-	if env.environment == 'staging':
-		sudo('ln -sf {}/deploy/staging/supervisor.conf /etc/supervisor/conf.d/chamados_cmc.conf'.format(PROJECT_ROOT))
-		sudo('ln -sf {}/deploy/staging/nginx.conf /etc/nginx/sites-enabled/chamados_cmc'.format(PROJECT_ROOT))
-		sudo('chmod a+x {}/deploy/staging/run.sh'.format(PROJECT_ROOT))
-	elif env.environment == 'production':
-		sudo('ln -sf {}/deploy/production/supervisor.conf /etc/supervisor/conf.d/chamados_cmc.conf'.format(PROJECT_ROOT))
-		sudo('ln -sf {}/deploy/production/nginx.conf /etc/nginx/sites-enabled/chamados_cmc'.format(PROJECT_ROOT))
-		sudo('chmod a+x {}/deploy/production/run.sh'.format(PROJECT_ROOT))
+	if env.environment == 'staging' or env.environment == 'production':
+		sudo('ln -sf {}/deploy/{}/supervisor.conf /etc/supervisor/conf.d/chamados_cmc.conf'.format(PROJECT_ROOT,env.environment))
+		sudo('ln -sf {}/deploy/{}/nginx.conf /etc/nginx/sites-enabled/chamados_cmc'.format(PROJECT_ROOT,env.environment))
+		sudo('chmod a+x {}/deploy/{}/bootstrap.sh'.format(PROJECT_ROOT,env.environment))
+		sudo('chmod a+x {}/deploy/{}/run.sh'.format(PROJECT_ROOT,env.environment))
 	else:
 		print('Nenhum ambiente selecionado. Defina staging ou production.')
 


### PR DESCRIPTION
Configuração adicionada ao supervisor da aplicação (staging e production) para criar pastas no /var/run onde os sockets serão criados.
fixes #93 